### PR TITLE
Add recently_played_window to API method

### DIFF
--- a/app/controllers/api/v1/widget_controller.rb
+++ b/app/controllers/api/v1/widget_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class WidgetController < BaseController
+      include PlayHistoryDefaults
+
       def search
         query = params[:q].to_s.strip
 
@@ -92,14 +94,15 @@ module Api
       end
 
       def recently_played
-        days = (params[:days] || ENV["DAYS_AGO_PLAY_HISTORY"] || 7).to_i
+        days = (params[:days] || DEFAULT_PLAY_HISTORY_DAYS).to_i
         media_items = MediaItem.recently_played(days)
                                .includes(:location, :media_type, release: [ :media_owner, :cover_image_attachment, :release_tracks ])
 
         render json: {
           items: media_items.map { |item| serialize_media_item(item) },
           total_duration: MediaItem.total_duration(media_items),
-          total_duration_formatted: format_duration(MediaItem.total_duration(media_items))
+          total_duration_formatted: format_duration(MediaItem.total_duration(media_items)),
+          recently_played_window: DEFAULT_PLAY_HISTORY_DAYS
         }
       end
 

--- a/app/controllers/concerns/play_history_defaults.rb
+++ b/app/controllers/concerns/play_history_defaults.rb
@@ -1,0 +1,5 @@
+module PlayHistoryDefaults
+  extend ActiveSupport::Concern
+
+  DEFAULT_PLAY_HISTORY_DAYS = (ENV["DAYS_AGO_PLAY_HISTORY"] || 7).to_i
+end

--- a/app/controllers/now_playing_controller.rb
+++ b/app/controllers/now_playing_controller.rb
@@ -1,4 +1,6 @@
 class NowPlayingController < ApplicationController
+  include PlayHistoryDefaults
+
   def index
     @media_type = params[:media_type] || "Vinyl"
 
@@ -6,7 +8,7 @@ class NowPlayingController < ApplicationController
     @now_playing = MediaItem.now_playing
                             .includes(:media_type)
                             .first
-    @days_ago_play_history = ENV["DAYS_AGO_PLAY_HISTORY"] || 7 # Default to 7 days,
+    @days_ago_play_history = DEFAULT_PLAY_HISTORY_DAYS
 
     # Recently played (not currently playing, has been played before) - show all media types
     @recently_played = MediaItem.recently_played(@days_ago_play_history.to_i)

--- a/test/controllers/api/v1/widget_controller_test.rb
+++ b/test/controllers/api/v1/widget_controller_test.rb
@@ -561,8 +561,10 @@ class Api::V1::WidgetControllerTest < ActionDispatch::IntegrationTest
     assert result.key?("items")
     assert result.key?("total_duration")
     assert result.key?("total_duration_formatted")
+    assert result.key?("recently_played_window")
     assert_kind_of Array, result["items"]
     assert_kind_of Integer, result["total_duration"]
+    assert_kind_of Integer, result["recently_played_window"]
   end
 
   test "recently_played should include items played within default 7 days" do


### PR DESCRIPTION
DRY the days in the recently played window via concern
Expose the duration of recently played (e.g. 7 days) to API